### PR TITLE
Move time-compat to other dependencies

### DIFF
--- a/structured/structured.cabal
+++ b/structured/structured.cabal
@@ -47,7 +47,6 @@ library
     , bytestring    >=0.10.4.0 && <0.11
     , containers    >=0.5.5.1  && <0.7
     , text          >=1.2.3.0  && <1.3
-    , time-compat   >=1.9.2.2  && <1.10
     , transformers  >=0.3.0.0  && <0.6
 
   -- other dependencies
@@ -57,6 +56,7 @@ library
     , hashable              >=1.2     && <1.4
     , scientific            >=0.3     && <0.4
     , tagged                >=0.7     && <0.9
+    , time-compat           >=1.9.2.2 && <1.10
     , unordered-containers  >=0.2     && <0.3
     , uuid-types            >=1.0.3   && <1.1
     , vector                >=0.10    && <0.13


### PR DESCRIPTION
It's not bundled with GHC.